### PR TITLE
Changed the Upper DM Limit on NREO Calculation

### DIFF
--- a/opercap.f90
+++ b/opercap.f90
@@ -185,7 +185,7 @@ subroutine captn_oper(mx_in, jx_in, niso, capped)!, isotopeChosen)
     integer ri, eli, limit!, i
     double precision, intent(in) :: mx_in, jx_in
     double precision :: capped !this is the output
-    double precision :: a, muminus, umax, umin, vesc, partialCapped, elementalResult, integrateResult
+    double precision :: maxcap, maxcapped, a, muminus, umax, umin, vesc, partialCapped, elementalResult, integrateResult
     double precision :: epsabs, epsrel, abserr, neval !for integrator
     double precision :: ier,alist,blist,rlist,elist,iord,last !for integrator
     ! double precision, allocatable :: u_int_res(:)
@@ -372,9 +372,9 @@ subroutine captn_oper(mx_in, jx_in, niso, capped)!, isotopeChosen)
 
     capped = 4.d0*pi*Rsun**3*capped
 
-    if (capped .gt. 1.d100) then
-      print*,"Capt'n General says: Oh my, it looks like you are capturing an", &
-        "infinite amount of dark matter in the Sun. Best to look into that."
+    maxcapped = maxcap(mx_in)
+    if (capped .gt. maxcapped) then
+      capped = maxcapped
     end if
 end subroutine captn_oper
 


### PR DESCRIPTION
Previously the captn_oper code was only checking that the final capture rate was below 1.d100. Now properly checks that it is below the geometric limit.