### PR TITLE
Suppress Wargument-mismatch on pchip.f90 and fftpack5.f90

### DIFF
--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ $(NUMFOBJ): %.o : $(NUMDIR)/%.f
 	$(FC) $(FOPT) -c  $<
 
 $(NUMF90OBJ): %.o : $(NUMDIR)/%.f90
-	$(FC) $(FOPT) -c  $<
+	$(FC) $(FOPT) -Wno-argument-mismatch -c  $<
 
 $(TSOBJ): %.o : $(TSDIR)/%.f
 	$(FC) $(FOPT) -c  $<


### PR DESCRIPTION
Added the -Wno-argument-mismatch flag to the NUMF90OBJ build target to suppress the numerous warnings about the legacy code.